### PR TITLE
[main] csrf 대응 코드 추가

### DIFF
--- a/src/apis/auth-request.service.ts
+++ b/src/apis/auth-request.service.ts
@@ -1,0 +1,18 @@
+import { inject, Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+import { environment } from '@/environments/environment';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AuthRequestService {
+  private http = inject(HttpClient);
+  private readonly apiUrl = environment.API_SERVER;
+
+  getCsrfToken() {
+    return this.http.get<{ csrfToken: string }>(`${this.apiUrl}csrf/token`, {
+      withCredentials: true
+    });
+  }
+}

--- a/src/apis/photo-request.service.ts
+++ b/src/apis/photo-request.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { environment } from '@/environments/environment';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 
 import type { UploadImagesResponse } from '@/apis/types/photo-request.type';
 
@@ -11,7 +11,10 @@ export class PhotoRequestService {
   private http = inject(HttpClient);
   private readonly apiUrl = environment.API_SERVER;
 
-  uploadPhotos(formData: FormData) {
-    return this.http.post<UploadImagesResponse>(`${this.apiUrl}image/upload`, formData);
+  uploadPhotos(formData: FormData, csrfToken: string) {
+    return this.http.post<UploadImagesResponse>(`${this.apiUrl}image/upload`, formData, {
+      headers: new HttpHeaders({ 'x-csrf-token': csrfToken }),
+      withCredentials: true
+    });
   }
 }

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -1,8 +1,13 @@
 <section class="section first">
-  <label class="image-upload-button" role="button">
-    이미지 첨부하기
-    <input hidden type="file" (change)="saveAttachImages($event)" multiple accept="image/*" />
-  </label>
+  <button class="image-upload-button" type="button" (click)="onInputTrigger($event)">이미지 첨부하기</button>
+  <input
+    #imageUploadInput
+    class="image-upload-input"
+    type="file"
+    (change)="saveAttachImages($event)"
+    multiple
+    accept="image/*"
+  />
 </section>
 <section class="section second">
   <div>second section</div>

--- a/src/app/home/home.component.scss
+++ b/src/app/home/home.component.scss
@@ -37,3 +37,7 @@
     background-color: #0056b3;
   }
 }
+
+.image-upload-input {
+  display: none; // Hide the default file input
+}

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,14 +1,23 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, viewChild } from '@angular/core';
+
 import { PhotoRequestService } from '@/apis/photo-request.service';
+import { AuthRequestService } from '@/apis/auth-request.service';
 
 import type { HttpErrorResponse } from '@angular/common/http';
+import type { ElementRef, OnInit } from '@angular/core';
 
 @Component({
   templateUrl: './home.component.html',
   styleUrl: './home.component.scss'
 })
-export class HomeComponent {
+export class HomeComponent implements OnInit {
   private photoRequestService = inject(PhotoRequestService);
+  private authRequestService = inject(AuthRequestService);
+
+  // TODO: CSRF 토큰 저장 및 관리 방식 고민 필요
+  private csrfToken = '';
+
+  readonly imageUploadInput = viewChild<ElementRef<HTMLInputElement>>('imageUploadInput');
 
   saveAttachImages(event: Event) {
     const formData = new FormData();
@@ -24,14 +33,34 @@ export class HomeComponent {
     }
   }
 
+  onInputTrigger(e: Event) {
+    e.preventDefault();
+
+    const inputElement = this.imageUploadInput();
+
+    if (!inputElement) return;
+    inputElement.nativeElement.click();
+  }
+
   uploadPhotos(formData: FormData) {
-    this.photoRequestService.uploadPhotos(formData).subscribe({
+    this.photoRequestService.uploadPhotos(formData, this.csrfToken).subscribe({
       // TODO: 응답 및 에러에 관련된 핸들링 추가 필요
       next: (response) => {
         console.log('Upload successful:', response.imageUrls);
       },
       error: (error: HttpErrorResponse) => {
         console.error(error);
+      }
+    });
+  }
+
+  ngOnInit(): void {
+    this.authRequestService.getCsrfToken().subscribe({
+      next: (response) => {
+        this.csrfToken = response.csrfToken;
+      },
+      error: (error: HttpErrorResponse) => {
+        console.error('Error fetching CSRF token:', error);
       }
     });
   }


### PR DESCRIPTION
## 1. 반영 사항
- [x] CSRF 관련 대응 사항이 백엔드에 추가되어 프론트에도 동일하게 적용
  - CSRF 토큰을 헤더 및 쿠키 인증방식을 추가로 적용
- [x] input hidden 속성으로 인해 렌더링 지연문제로 탐색창이 제대로 로드 되지 않는 방법 우회 적용
  - button태그를 활용해서 input ref에 접근하여 click 이벤트로 트리거 처리
  - 해당 방식을 적용함으로써 label < input 의 관계에서 발생할 수 있는 이벤트 버블링에 의한 중복 트리거 등을 방지할 수 있음

## 2. TODO
- [ ] 차후 서버에서 발급받는 CSRF 토큰을 어떻게 관리할 것인지 판단 필요